### PR TITLE
Suggest additional scripts to run using the internal IMU

### DIFF
--- a/LiLi-OM/CMakeLists.txt
+++ b/LiLi-OM/CMakeLists.txt
@@ -7,6 +7,7 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14 -O3")
 ## Find catkin macros and libraries
 find_package(catkin REQUIRED COMPONENTS
   roscpp
+  rospy
   std_msgs
   nav_msgs
   sensor_msgs
@@ -27,7 +28,7 @@ message(STATUS "Using Ceres version ${CERES_VERSION}")
 catkin_package(
     # LIBRARIES ${PROJECT_NAME}
     INCLUDE_DIRS include
-    CATKIN_DEPENDS roscpp message_runtime std_msgs nav_msgs geometry_msgs
+    CATKIN_DEPENDS roscpp rospy message_runtime std_msgs nav_msgs geometry_msgs
     DEPENDS EIGEN3
 )
 

--- a/LiLi-OM/config/config_fr_iosb_internal_imu.yaml
+++ b/LiLi-OM/config/config_fr_iosb_internal_imu.yaml
@@ -1,0 +1,42 @@
+common:
+  frame_id: "lili_om"
+  
+preprocessing:
+  surf_thres: 0.28 
+  edge_thres: 4 
+
+lidar_odometry:
+  max_num_iter: 15
+  scan_match_cnt: 1
+  if_to_deskew: false
+
+backend_fusion:
+  imu_topic: "/imu/data"
+  max_num_iter: 15 
+  local_map_width: 40
+  slide_window_width: 3 
+  lidar_const: 20 
+  reflect_thres: 15.0
+  surf_dist_thres: 0.12
+  kd_max_radius: 1.0
+  surf_ds: 0.4
+  edge_ds: 0.2
+  loop_closure_on: true
+  global_lc_time_thres: 25.0
+  local_lc_time_thres: 25.0
+  lc_search_radius: 10
+  lc_map_width: 20
+  lc_icp_thres: 0.1 #iosb_large: 0.1
+  mapping_interval: 7
+  save_pcd: false
+  mapping_ds: 0.3
+
+#extrinsic imu to lidar
+  ql2b_w: 1
+  ql2b_x: 0
+  ql2b_y: 0
+  ql2b_z: 0
+
+  tl2b_x: -0.05512
+  tl2b_y: -0.02226
+  tl2b_z: 0.02970

--- a/LiLi-OM/launch/run_fr_iosb_internal_imu.launch
+++ b/LiLi-OM/launch/run_fr_iosb_internal_imu.launch
@@ -1,0 +1,24 @@
+<launch>
+    
+    <!--- Sim Time -->
+    <param name="/use_sim_time" value="true" />
+
+    <!--- Run Rviz-->
+    <node pkg="rviz" type="rviz" name="rviz" args="-d $(find lili_om)/config/test.rviz" />
+
+    <!-- Parameters -->
+    <rosparam file = "$(find lili_om)/config/config_fr_iosb_internal_imu.yaml"/>
+
+    <node pkg="tf" type="static_transform_publisher" name="lili_om" args="0 0 0 0 0 0 base_link lili_om 200"/>
+
+    <node pkg="lili_om" type="InternalImuUnitConverter.py" name="UnitConverter" output="screen"/>
+
+    <!--- lili_om -->
+    <node pkg="lili_om" type="FormatConvert" name="FormatConvert" output="screen"/>
+    <node pkg="lili_om" type="Preprocessing" name="Preprocessing" output="screen">
+      <remap from="/livox/imu" to="/imu/data" />
+    </node>
+    <node pkg="lili_om" type="LidarOdometry" name="LidarOdometry" output="screen"/>
+    <node pkg="lili_om" type="BackendFusion" name="BackendFusion" output="screen"/>
+
+</launch>

--- a/LiLi-OM/launch/run_fr_iosb_internal_imu.launch
+++ b/LiLi-OM/launch/run_fr_iosb_internal_imu.launch
@@ -1,7 +1,7 @@
 <launch>
     
     <!--- Sim Time -->
-    <param name="/use_sim_time" value="true" />
+    <param name="/use_sim_time" value="false" />
 
     <!--- Run Rviz-->
     <node pkg="rviz" type="rviz" name="rviz" args="-d $(find lili_om)/config/test.rviz" />
@@ -15,9 +15,7 @@
 
     <!--- lili_om -->
     <node pkg="lili_om" type="FormatConvert" name="FormatConvert" output="screen"/>
-    <node pkg="lili_om" type="Preprocessing" name="Preprocessing" output="screen">
-      <remap from="/livox/imu" to="/imu/data" />
-    </node>
+    <node pkg="lili_om" type="Preprocessing" name="Preprocessing" output="screen"/>
     <node pkg="lili_om" type="LidarOdometry" name="LidarOdometry" output="screen"/>
     <node pkg="lili_om" type="BackendFusion" name="BackendFusion" output="screen"/>
 

--- a/LiLi-OM/package.xml
+++ b/LiLi-OM/package.xml
@@ -12,6 +12,7 @@
 
   <buildtool_depend>catkin</buildtool_depend>
   <depend>roscpp</depend>
+  <depend>rospy</depend>
   <depend>std_msgs</depend>
   <depend>nav_msgs</depend>
   <depend>sensor_msgs</depend>

--- a/LiLi-OM/scripts/InternalImuUnitConverter.py
+++ b/LiLi-OM/scripts/InternalImuUnitConverter.py
@@ -1,0 +1,75 @@
+#!/usr/bin/python
+
+import tf
+import rospy
+import math
+from sensor_msgs.msg import Imu
+
+class imu_rescaller:
+  def __init__(self):
+    self.unit_acc = 9.8
+    self.orientation_avg_num = 3
+
+    pub_topic_name = "/imu/data"
+    sub_topic_name = "/livox/imu"
+
+    self.pub = rospy.Publisher(pub_topic_name, Imu, queue_size = 10)
+    rospy.Subscriber(sub_topic_name, Imu, self.callback)
+
+    self.orientation_avg_count = 0
+    self.imu_first_msg = Imu()
+    
+    self.imu_first_msg.linear_acceleration.x = 0
+    self.imu_first_msg.linear_acceleration.y = 0
+    self.imu_first_msg.linear_acceleration.z = 0
+
+  def callback(self, imu):
+    msg = Imu()
+    msg = imu
+    
+    msg.linear_acceleration.x = imu.linear_acceleration.x * self.unit_acc
+    msg.linear_acceleration.y = imu.linear_acceleration.y * self.unit_acc
+    msg.linear_acceleration.z = imu.linear_acceleration.z * self.unit_acc
+
+    msg.angular_velocity.x = imu.angular_velocity.x
+    msg.angular_velocity.y = imu.angular_velocity.y
+    msg.angular_velocity.z = imu.angular_velocity.z
+
+    if self.orientation_avg_count < self.orientation_avg_num:
+      self.imu_first_msg.linear_acceleration.x += msg.linear_acceleration.x
+      self.imu_first_msg.linear_acceleration.y += msg.linear_acceleration.y
+      self.imu_first_msg.linear_acceleration.z += msg.linear_acceleration.z
+
+      self.orientation_avg_count += 1
+      
+      if self.orientation_avg_count == self.orientation_avg_num:
+        self.imu_first_msg.linear_acceleration.x /= self.orientation_avg_num
+        self.imu_first_msg.linear_acceleration.y /= self.orientation_avg_num
+        self.imu_first_msg.linear_acceleration.z /= self.orientation_avg_num
+        
+        ax = self.imu_first_msg.linear_acceleration.x
+        ay = self.imu_first_msg.linear_acceleration.y
+        az = self.imu_first_msg.linear_acceleration.z
+
+        r = math.atan2(ay, az)
+        p = math.atan2(-ax, math.sqrt(ay**2 + az**2))
+        y = 0
+
+        q = tf.transformations.quaternion_from_euler(r, p, y)
+        self.imu_first_msg.orientation.x = q[0]
+        self.imu_first_msg.orientation.y = q[1]
+        self.imu_first_msg.orientation.z = q[2]
+        self.imu_first_msg.orientation.w = q[3]
+        
+    else: 
+      msg.header = imu.header
+      msg.orientation = self.imu_first_msg.orientation
+      self.pub.publish(msg)
+
+def main():
+    rospy.init_node("rescale_imu")
+    rescaller = imu_rescaller()
+    rospy.spin()
+
+if __name__ == "__main__":
+    main()

--- a/LiLi-OM/scripts/InternalImuUnitConverter.py
+++ b/LiLi-OM/scripts/InternalImuUnitConverter.py
@@ -13,7 +13,7 @@ class imu_rescaller:
     pub_topic_name = "/imu/data"
     sub_topic_name = "/livox/imu"
 
-    self.pub = rospy.Publisher(pub_topic_name, Imu, queue_size = 10)
+    self.pub = rospy.Publisher(pub_topic_name, Imu, queue_size = 200)
     rospy.Subscriber(sub_topic_name, Imu, self.callback)
 
     self.orientation_avg_count = 0
@@ -30,10 +30,6 @@ class imu_rescaller:
     msg.linear_acceleration.x = imu.linear_acceleration.x * self.unit_acc
     msg.linear_acceleration.y = imu.linear_acceleration.y * self.unit_acc
     msg.linear_acceleration.z = imu.linear_acceleration.z * self.unit_acc
-
-    msg.angular_velocity.x = imu.angular_velocity.x
-    msg.angular_velocity.y = imu.angular_velocity.y
-    msg.angular_velocity.z = imu.angular_velocity.z
 
     if self.orientation_avg_count < self.orientation_avg_num:
       self.imu_first_msg.linear_acceleration.x += msg.linear_acceleration.x
@@ -62,7 +58,6 @@ class imu_rescaller:
         self.imu_first_msg.orientation.w = q[3]
         
     else: 
-      msg.header = imu.header
       msg.orientation = self.imu_first_msg.orientation
       self.pub.publish(msg)
 

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ rosbag play FR_IOSB_Short_64.bag -r 1.0 --clock --pause
 ```
 
 - Example for running lili_om (When using Livox Horizon's internal IMU):  
-*When using the internal IMU, the LiDAR must be stationary at the start.*
+\*When using the internal IMU, the LiDAR must be stationary at the start.
 ```
 roslaunch lili_om run_fr_iosb_internal_imu.launch
 rosbag play FR_IOSB_Short.bag -r 1.0 --clock --pause --topics /livox/lidar /livox/imu

--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ rosbag play FR_IOSB_Short_64.bag -r 1.0 --clock --pause
 ```
 
 - Example for running lili_om (When using Livox Horizon's internal IMU):
+*When using the internal IMU, the LiDAR must be stationary at the start.*
 ```
 roslaunch lili_om run_fr_iosb_internal_imu.launch
 rosbag play FR_IOSB_Short.bag -r 1.0 --clock --pause --topics /livox/lidar /livox/imu

--- a/README.md
+++ b/README.md
@@ -69,6 +69,12 @@ roslaunch lili_om_rot run_fr_iosb.launch
 rosbag play FR_IOSB_Short_64.bag -r 1.0 --clock --pause
 ```
 
+- Example for running lili_om (When using Livox Horizon's internal IMU):
+```
+roslaunch lili_om run_fr_iosb_internal_imu.launch
+rosbag play FR_IOSB_Short.bag -r 1.0 --clock --pause --topics /livox/lidar /livox/imu
+```
+
 ## Contributors
 Meng Li (Email: [limeng1523@outlook.com](limeng1523@outlook.com))
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ roslaunch lili_om_rot run_fr_iosb.launch
 rosbag play FR_IOSB_Short_64.bag -r 1.0 --clock --pause
 ```
 
-- Example for running lili_om (When using Livox Horizon's internal IMU):
+- Example for running lili_om (When using Livox Horizon's internal IMU):  
 *When using the internal IMU, the LiDAR must be stationary at the start.*
 ```
 roslaunch lili_om run_fr_iosb_internal_imu.launch


### PR DESCRIPTION
Hello.

It seems that some users are interested in running on the internal IMU, so submit the files needed to run on the internal IMU.

The script converts the units of linear_acceleration in the internal IMU from "G" to "m/s^2".
It also averages the first few frames and decomposes the gravitational acceleration to predict the initial roll and pitch angles.

The Config file is based on "config_fr_iosb.yaml" with some external parameters modified.

Using these submissions, I have confirmed that I can SLAM correctly with FR_IOSB_Short.bag and FR_IOSB_Long.bag.

Working with an internal IMU is not an essential issue, so I will leave the merge decision to you.
If there are any items that may interfere with the merge, please reply me and I will fix them.